### PR TITLE
Update cpp_to_rust_common bincode dependency version

### DIFF
--- a/cpp_to_rust/cpp_to_rust_common/Cargo.toml
+++ b/cpp_to_rust/cpp_to_rust_common/Cargo.toml
@@ -19,7 +19,7 @@ regex = "0.1"
 serde = "0.9"       # serialization
 serde_derive = "0.9"
 serde_json = "0.9"
-bincode = "1.0.0-alpha6"
+bincode = "0.7.0"
 
 term-painter = "0.2.3"   # colored output
 


### PR DESCRIPTION
bincode `0.7.0` is actually non-yanked `1.0.0-alpha7`, which in turn has some fixes on top of `1.0.0-alpha6`.
Currently you can't use qt crates simply due to yanked transitive dependency on bincode. This change fixes that.