### PR TITLE
Fix linker error on OSX

### DIFF
--- a/cpp_to_rust/cpp_to_rust_generator/Cargo.toml
+++ b/cpp_to_rust/cpp_to_rust_generator/Cargo.toml
@@ -26,3 +26,4 @@ clippy = {version = "0.0", optional = true} # linter
 
 cpp_to_rust_common = { version = "0.2.3", path = "../../cpp_to_rust/cpp_to_rust_common" }
 
+lazy_static = "1.0" # regex caching

--- a/cpp_to_rust/cpp_to_rust_generator/src/lib.rs
+++ b/cpp_to_rust/cpp_to_rust_generator/src/lib.rs
@@ -21,6 +21,9 @@ extern crate regex;
 extern crate clang;
 
 #[macro_use]
+extern crate lazy_static;
+
+#[macro_use]
 extern crate serde_derive;
 
 extern crate serde;

--- a/qt_generator/qt_generator_common/src/lib.rs
+++ b/qt_generator/qt_generator_common/src/lib.rs
@@ -61,7 +61,17 @@ pub fn get_installation_data(sublib_name: &str) -> Result<InstallationData> {
   log::status(format!("QT_INSTALL_DOCS = \"{}\"", docs_path.display()));
   let folder_name = lib_folder_name(sublib_name);
   let dir = root_include_path.with_added(&folder_name);
-  if dir.exists() {
+  let dir2 = lib_path.with_added(format!("{}.framework/Headers", folder_name));
+  if dir2.exists() {
+    Ok(InstallationData {
+         root_include_path: root_include_path,
+         lib_path: lib_path,
+         docs_path: docs_path,
+         lib_include_path: dir2,
+         is_framework: true,
+         qt_version: qt_version,
+       })
+  } else if dir.exists() {
     Ok(InstallationData {
          root_include_path: root_include_path,
          lib_path: lib_path,
@@ -71,22 +81,10 @@ pub fn get_installation_data(sublib_name: &str) -> Result<InstallationData> {
          qt_version: qt_version,
        })
   } else {
-    let dir2 = lib_path.with_added(format!("{}.framework/Headers", folder_name));
-    if dir2.exists() {
-      Ok(InstallationData {
-           root_include_path: root_include_path,
-           lib_path: lib_path,
-           docs_path: docs_path,
-           lib_include_path: dir2,
-           is_framework: true,
-           qt_version: qt_version,
-         })
-    } else {
-      Err(format!("extra header dir not found (tried: {}, {})",
-                  dir.display(),
-                  dir2.display())
-              .into())
-    }
+    Err(format!("extra header dir not found (tried: {}, {})",
+                dir.display(),
+                dir2.display())
+            .into())
   }
 }
 


### PR DESCRIPTION
The root include path exists even when there are frameworks.  Look for frameworks first to properly populate is_framwork variable as frameworks are only on OSX & thus won't conflict with other platforms.  Fixes #67